### PR TITLE
Fix version and transient dependencies

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -5,7 +5,6 @@
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="openjdk-23" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -2,8 +2,6 @@ plugins {
     `java-library`
 }
 
-version = "1.0.0"
-
 dependencies {
     api(libs.bundles.sadu)
     api(libs.dbdriver.postgres)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,7 @@ group = "de.sakuramc.core"
 version = "1.0.0"
 
 allprojects {
+    version = rootProject.version
     group = rootProject.group
     apply {
         plugin<JavaPlugin>()

--- a/paper/build.gradle.kts
+++ b/paper/build.gradle.kts
@@ -4,12 +4,11 @@ plugins {
     alias(libs.plugins.shadow)
 }
 
-version = "1.0.0"
-
 dependencies {
     implementation(project(":api")) {
         exclude(group = "*", module = "*")
     }
+    compileOnlyApi(project(":api"))
     compileOnly(libs.jetbrains.annotations)
 
     compileOnly(libs.lombok)

--- a/velocity/build.gradle.kts
+++ b/velocity/build.gradle.kts
@@ -1,12 +1,12 @@
 plugins {
+    `java-library`
     alias(libs.plugins.shadow)
 }
-
-version = "1.0.0"
 
 dependencies{
     compileOnly(libs.velocity.api)
     implementation(project(":api"))
+    compileOnlyApi(project(":api"))
 
     compileOnly(libs.lombok)
     annotationProcessor(libs.lombok)


### PR DESCRIPTION
Set a global version. Otherwise publishing would fail all the time unless all versions are changed. Either split up the modules into different repositories or use some hacky per project workflows (not recommended) if this is not desired.
That was all modules will have the same version all the time.

Importing paper and velocity module will now expose the api module and its dependencies as runtimeOnly dependencies.